### PR TITLE
refactor: use dbdocs for high-level db architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,19 @@ brew install postgresql
 Another easier way is to use supabase or render database instances. You can find the env variables in the dashboard for those services.
 
 NOTE: More details [here](drizzle/README.md)
+
+### Database Documentation (Dbdocs)
+
+We use **dbdocs** to generate and maintain documentation for the database schema. The documentation is stored and versioned, and can be viewed locally for internal use.
+
+#### Prerequisites
+
+- **dbdocs CLI**: You can install the dbdocs CLI tool globally like below. Note: This is only necessary if you are going to use db2dbml commands or similar. Basic commands are implemented via npx in our scripts. See `dbdocs:login` and `dbdocs:build`.
+
+#### Installation (optional)
+
+1. **Install the Dbdocs CLI**:
+   Run the following command to install Dbdocs globally:
+   ```bash
+   npm install -g dbdocs
+   ```

--- a/database.dbml
+++ b/database.dbml
@@ -1,0 +1,20 @@
+Table "lpdd"."organization_contacts" {
+  "id" int4 [pk, not null, increment]
+  "first_name" text [not null]
+  "last_name" text [not null]
+  "email" text [unique, not null]
+  "organization_id" int4
+}
+
+Table "lpdd"."organizations" {
+  "id" int4 [pk, not null, increment]
+  "name" text [not null]
+  "logo_url" text
+  "description" text
+  "industry" text
+  "website_url" text [not null]
+  "city" text [not null]
+  "region" text
+}
+
+Ref "organization_contacts_organization_id_organizations_id_fk":"lpdd"."organizations"."id" < "lpdd"."organization_contacts"."organization_id"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "next lint",
     "migration:generate": "drizzle-kit generate",
-    "migration:apply": "drizzle-kit migrate"
+    "migration:apply": "drizzle-kit migrate",
+    "dbdocs:login": "npx dbdocs login",
+    "dbdocs:build": "npx dbdocs build database.dbml"
   },
   "dependencies": {
     "@next/env": "^14.2.5",


### PR DESCRIPTION
The use case for this is to keep our db architecture diagrams / planning within our codebase.
This will allow us to have a version source of truth. 

Previously, I used https://dbdiagram.io/ to create our diagrams but the  free version required us to share a file. Cloud sharing was only possible with paid plan. I hope this will allow us to keep our diagrams up-to-date with our actual drizzle configurations. Also we can make changes here and discuss prior to making live db changes. 

note: I generated the dbml file from this command `db2dbml postgres 'postgresql://postgres.{username}:{password}@aws-0-us-east-1.pooler.supabase.com:6543/postgres?schemas=lpdd' -o database.dbml`