### PR TITLE
docs: Vercel-biased docs & update Drizzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Latiné Professional Development Directory (LPDD)
+
+A full-stack software application for the Chicago-based non-profit professional
+development organizations where visitors can view organizations and events.
 
 ## Getting Started
 
@@ -22,34 +25,9 @@ In the `.env` file, fill in the variables that are need (i.e. db credentials, se
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
 
 ## Tech Stack
 

--- a/drizzle/README.md
+++ b/drizzle/README.md
@@ -21,11 +21,55 @@ Before using Drizzle, ensure that you have correctly configured your environment
 ```
 POSTGRES_HOST=your-postgres-host
 POSTGRES_DATABASE=your-database-name
+POSTGRES_PORT=5432
 POSTGRES_USER=your-database-user
 POSTGRES_PASSWORD=your-database-password
 ```
 
 These variables are used to establish a connection with the PostgreSQL database.
+
+<details>
+<summary>⚠️  Need help?</summary>
+
+After installing PostgreSQL, you may not know the values for some of the
+variables mentioned above. It's also possible that you don't have a PostgreSQL
+user, password, nor database setup.
+
+To setup these values, you can run the following commands to attach to your
+local fresh PostgreSQL installation and run some SQL commands to create the
+role, password, and database with the proper permissions setup.
+
+**Connect to your fresh PostgreSQL installation**
+
+```sh
+psql postgres
+```
+
+**Create the role (user) with a password**
+
+```sql
+CREATE ROLE lpdd WITH LOGIN PASSWORD 'lpdd';
+```
+
+**Add the CREATEDB attribute to your new role**
+
+```sql
+ALTER ROLE lpdd CREATEDB;
+```
+
+**Create the database**
+
+```sql
+CREATE DATABASE lpdd;
+```
+
+**Add the privileges on the `lpdd` database to the the `lpdd` role**
+
+```sql
+GRANT ALL PRIVILEGES ON DATABASE lpdd TO lpdd;
+```
+
+</details>
 
 ## Running Migrations
 


### PR DESCRIPTION
I removed a few things here to help standardize things. I've also updated the Drizzle documentation to include the `POSTGRES_PORT` and setting up the role, database, and privileges for the role on the database in the documentation. It's helpful for folks starting from scratch on a freshly installed PostgreSQL instance.