### PR TITLE
[BUG] Selecting an Industry checkbox causes a jump in the UI

### DIFF
--- a/src/components/Directory/index.tsx
+++ b/src/components/Directory/index.tsx
@@ -16,7 +16,7 @@ export default function Directory() {
   );
 
   return (
-    <section className="mb-4 flex flex-col items-center pb-4 pt-8">
+    <section className="mb-4 flex w-10/12 flex-col items-center pb-4 pt-8">
       <h1 className="pb-8 text-center text-lg font-semibold sm:text-4xl">
         Directory
       </h1>

--- a/src/components/Directory/index.tsx
+++ b/src/components/Directory/index.tsx
@@ -20,7 +20,7 @@ export default function Directory() {
       <h1 className="pb-8 text-center text-lg font-semibold sm:text-4xl">
         Directory
       </h1>
-      <div className="min-h-[760px] w-10/12 min-w-[325px] rounded-lg border border-border bg-background p-4 shadow-lg md:min-h-[620px] md:w-3/4 dark:shadow-gray-800">
+      <div className="min-h-[760px] rounded-lg border border-border bg-background p-4 shadow-lg md:w-full dark:shadow-gray-800">
         <div className="mb-6 md:flex md:gap-x-2">
           <Filter
             industries={industries}

--- a/src/components/Directory/index.tsx
+++ b/src/components/Directory/index.tsx
@@ -20,7 +20,7 @@ export default function Directory() {
       <h1 className="pb-8 text-center text-lg font-semibold sm:text-4xl">
         Directory
       </h1>
-      <div className="min-h-[760px] w-10/12 min-w-[325px] rounded-lg border border-border bg-background p-4 shadow-lg md:min-h-[620px] md:w-3/4 md:min-w-[684px] dark:shadow-gray-800">
+      <div className="min-h-[760px] w-10/12 min-w-[325px] rounded-lg border border-border bg-background p-4 shadow-lg md:min-h-[620px] md:w-3/4 dark:shadow-gray-800">
         <div className="mb-6 md:flex md:gap-x-2">
           <Filter
             industries={industries}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -22,19 +18,10 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
     "target": "ES2017"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
[BUG] Selecting an Industry checkbox causes a jump in the UI: The directory container width was shrinking/stretching when selecting different industries in the filter dropdown.