### PR TITLE
Fix: Prevent directory container resizing with filter dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11064,6 +11064,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.14.tgz",
+      "integrity": "sha512-2u2XcSaDEOj+96eXpyjHjtVPLhkAFw2nlaz83EPeuK4obF+HmtDJHqgR1dZB7Gb6V/d55FL26/lYVd0TwMgcOQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/components/Directory/Filter/index.tsx
+++ b/src/components/Directory/Filter/index.tsx
@@ -57,10 +57,11 @@ export default function Filter({
 
   return (
     <div className="relative mt-4 md:mt-0 md:w-full">
+      {/* Filter Button */}
       <button
         ref={industryDropdownButtonRef}
         onClick={() => setIsIndustryDropdownOpen(!isIndustryDropdownOpen)}
-        className={`relative flex w-full items-center justify-between bg-brandGold px-4 py-2 transition-all duration-300 ease-out hover:shadow-lg md:h-12 md:w-1/2 dark:text-black ${
+        className={`flex w-full items-center justify-between bg-brandGold px-4 py-2 transition-all duration-300 ease-out hover:shadow-lg md:h-12 md:w-1/2 dark:text-black ${
           isIndustryDropdownOpen
             ? "rounded-t-lg font-semibold"
             : "rounded-lg font-normal"
@@ -79,33 +80,14 @@ export default function Filter({
         </div>
       </button>
 
-      {/* Fixed Height Chip Container */}
-      <div
-        className={`flex h-16 w-full min-w-[300px] flex-wrap gap-2 transition-opacity duration-300 ease-out ${
-          isIndustryDropdownOpen ? "invisible" : "visible"
-        }`}
-      >
-        {selectedIndustries.map((industry: Industry) => (
-          <button
-            key={industry}
-            onClick={() => removeIndustry(industry)}
-            className="flex items-center space-x-2 rounded-full bg-gradient-to-r from-chipGradientFrom via-chipGradientVia to-chipGradientTo px-3 py-1 focus:outline-none"
-          >
-            <span>{industry}</span>
-            <XIcon />
-          </button>
-        ))}
-      </div>
-
-      {/* Adjusted Dropdown Menu */}
+      {/* Dropdown Menu */}
       <div
         ref={industryDropdownRef}
-        className={`absolute w-full bg-background transition-all duration-300 ease-out md:w-1/2 ${
+        className={`absolute w-full transform bg-background transition-all duration-300 ease-out md:w-1/2 ${
           isIndustryDropdownOpen
-            ? "max-h-[500px] translate-y-[-4rem] rounded-b-lg border-b border-l border-r border-border p-4 opacity-100 shadow-2xl"
+            ? "max-h-[500px] translate-y-0 rounded-b-lg border-b border-l border-r border-border p-4 opacity-100 shadow-2xl"
             : "max-h-0 translate-y-0 border-none p-0 opacity-0 shadow-none"
         } overflow-hidden`}
-        style={{ top: "100%" }} // Ensure dropdown is positioned below the button
       >
         {industries.map((industry) => (
           <label
@@ -119,6 +101,22 @@ export default function Filter({
             />
             <span>{industry}</span>
           </label>
+        ))}
+      </div>
+
+      {/* Industry Chips Container */}
+      <div
+        className={`mt-4 flex min-h-0 w-full min-w-[300px] flex-wrap gap-x-2 gap-y-4 transition-opacity duration-300 ease-out`}
+      >
+        {selectedIndustries.map((industry: Industry) => (
+          <button
+            key={industry}
+            onClick={() => removeIndustry(industry)}
+            className="flex items-center space-x-2 rounded-full bg-gradient-to-r from-chipGradientFrom via-chipGradientVia to-chipGradientTo px-3 py-1 focus:outline-none"
+          >
+            <span>{industry}</span>
+            <XIcon />
+          </button>
         ))}
       </div>
     </div>

--- a/src/components/Directory/Filter/index.tsx
+++ b/src/components/Directory/Filter/index.tsx
@@ -60,14 +60,14 @@ export default function Filter({
       <button
         ref={industryDropdownButtonRef}
         onClick={() => setIsIndustryDropdownOpen(!isIndustryDropdownOpen)}
-        className={`flex w-full items-center justify-between bg-brandGold px-4 py-2 transition-all duration-300 ease-out hover:shadow-lg md:h-12 md:w-1/2 dark:text-black ${
+        className={`relative flex w-full items-center justify-between bg-brandGold px-4 py-2 transition-all duration-300 ease-out hover:shadow-lg md:h-12 md:w-1/2 dark:text-black ${
           isIndustryDropdownOpen
             ? "rounded-t-lg font-semibold"
             : "rounded-lg font-normal"
-        } `}
+        }`}
       >
         <div className="flex items-center">
-          <FilterIcon></FilterIcon>
+          <FilterIcon />
           <span className="ml-2">Filter by Industry</span>
         </div>
         <div
@@ -75,14 +75,15 @@ export default function Filter({
             isIndustryDropdownOpen ? "opacity-100" : "opacity-0"
           }`}
         >
-          <XIcon></XIcon>
+          <XIcon />
         </div>
       </button>
 
+      {/* Fixed Height Chip Container */}
       <div
-        className={`flex w-full flex-wrap gap-2 ${
-          selectedIndustries.length === 0 ? "mt-0" : "mt-4"
-        } ${isIndustryDropdownOpen ? "hidden" : "block"}`}
+        className={`flex h-16 w-full min-w-[300px] flex-wrap gap-2 transition-opacity duration-300 ease-out ${
+          isIndustryDropdownOpen ? "invisible" : "visible"
+        }`}
       >
         {selectedIndustries.map((industry: Industry) => (
           <button
@@ -91,18 +92,20 @@ export default function Filter({
             className="flex items-center space-x-2 rounded-full bg-gradient-to-r from-chipGradientFrom via-chipGradientVia to-chipGradientTo px-3 py-1 focus:outline-none"
           >
             <span>{industry}</span>
-            <XIcon></XIcon>
+            <XIcon />
           </button>
         ))}
       </div>
 
+      {/* Adjusted Dropdown Menu */}
       <div
         ref={industryDropdownRef}
-        className={`absolute w-full transform bg-background transition-all duration-300 ease-out md:w-1/2 ${
+        className={`absolute w-full bg-background transition-all duration-300 ease-out md:w-1/2 ${
           isIndustryDropdownOpen
-            ? "max-h-[500px] translate-y-0 rounded-b-lg border-b border-l border-r border-border p-4 opacity-100 shadow-2xl"
+            ? "max-h-[500px] translate-y-[-4rem] rounded-b-lg border-b border-l border-r border-border p-4 opacity-100 shadow-2xl"
             : "max-h-0 translate-y-0 border-none p-0 opacity-0 shadow-none"
         } overflow-hidden`}
+        style={{ top: "100%" }} // Ensure dropdown is positioned below the button
       >
         {industries.map((industry) => (
           <label
@@ -113,7 +116,7 @@ export default function Filter({
               type="checkbox"
               checked={selectedIndustries.includes(industry)}
               onChange={() => handleIndustryChange(industry)}
-            ></input>
+            />
             <span>{industry}</span>
           </label>
         ))}


### PR DESCRIPTION
Overview
This pull request resolves a UI bug where toggling the "Filter by Industry" dropdown caused the directory container width to jump and resulted in disappearing industry chips.

Problem
Issue: When industries were selected for filtering, the directory container would resize slightly upon toggling the filter button. Additionally, the industry chips would not display as expected when the dropdown was open.
Cause: The layout shift occurred because the chip container was dynamically added/removed, impacting the container’s dimensions.

Solution
Persistent Chip Container: Added a reserved space for the industry chips, even when no industries are selected, to prevent layout shifts.
Dropdown Alignment Fix: Adjusted the dropdown menu positioning to align directly under the filter button when opened.

Changes
Updated Filter component to keep chip space consistent.
CSS adjustments for dropdown alignment under the filter button.

Testing
Verified fixed-width directory container when toggling the filter.
Confirmed that selected industry chips display consistently without layout changes.