### PR TITLE
Add Key Services taxonomy to org profiles

### DIFF
--- a/drizzle/20260227000000_add_key_services_table.sql
+++ b/drizzle/20260227000000_add_key_services_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS lpdd.key_services (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS lpdd.organization_services (
+  id SERIAL PRIMARY KEY,
+  organization_id INTEGER REFERENCES lpdd.organizations(id),
+  service_id INTEGER REFERENCES lpdd.key_services(id)
+);

--- a/drizzle/20260227224303_hard_paper_doll.sql
+++ b/drizzle/20260227224303_hard_paper_doll.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "lpdd"."key_services" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	CONSTRAINT "key_services_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "lpdd"."organization_services" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"organization_id" integer,
+	"service_id" integer
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "lpdd"."organization_services" ADD CONSTRAINT "organization_services_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "lpdd"."organizations"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "lpdd"."organization_services" ADD CONSTRAINT "organization_services_service_id_key_services_id_fk" FOREIGN KEY ("service_id") REFERENCES "lpdd"."key_services"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/meta/20260227224303_snapshot.json
+++ b/drizzle/meta/20260227224303_snapshot.json
@@ -1,0 +1,1027 @@
+{
+  "id": "b74662f0-ed18-4029-96eb-6aefdc320875",
+  "prevId": "82db30fa-4191-4040-9680-deab875b1a8e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "lpdd.affinities": {
+      "name": "affinities",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "affinities_name_unique": {
+          "name": "affinities_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "lpdd.categories": {
+      "name": "categories",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "lpdd.cities": {
+      "name": "cities",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cities_name_unique": {
+          "name": "cities_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "lpdd.event_industries": {
+      "name": "event_industries",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry_id": {
+          "name": "industry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_industries_event_id_events_id_fk": {
+          "name": "event_industries_event_id_events_id_fk",
+          "tableFrom": "event_industries",
+          "tableTo": "events",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_industries_industry_id_industries_id_fk": {
+          "name": "event_industries_industry_id_industries_id_fk",
+          "tableFrom": "event_industries",
+          "tableTo": "industries",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "industry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "lpdd.event_organizations": {
+      "name": "event_organizations",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_organizations_event_id_events_id_fk": {
+          "name": "event_organizations_event_id_events_id_fk",
+          "tableFrom": "event_organizations",
+          "tableTo": "events",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_organizations_organization_id_organizations_id_fk": {
+          "name": "event_organizations_organization_id_organizations_id_fk",
+          "tableFrom": "event_organizations",
+          "tableTo": "organizations",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "lpdd.events": {
+      "name": "events",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_time": {
+          "name": "event_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_url": {
+          "name": "registration_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_virtual": {
+          "name": "is_virtual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'false'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_city_id_cities_id_fk": {
+          "name": "events_city_id_cities_id_fk",
+          "tableFrom": "events",
+          "tableTo": "cities",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "events_name_unique": {
+          "name": "events_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "lpdd.featured_orgs": {
+      "name": "featured_orgs",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "featured_orgs_org_id_organizations_id_fk": {
+          "name": "featured_orgs_org_id_organizations_id_fk",
+          "tableFrom": "featured_orgs",
+          "tableTo": "organizations",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "featured_orgs_org_id_unique": {
+          "name": "featured_orgs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      }
+    },
+    "lpdd.industries": {
+      "name": "industries",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "industries_name_unique": {
+          "name": "industries_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "lpdd.key_services": {
+      "name": "key_services",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "key_services_name_unique": {
+          "name": "key_services_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "lpdd.organization_affinities": {
+      "name": "organization_affinities",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affinity_id": {
+          "name": "affinity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_affinities_organization_id_organizations_id_fk": {
+          "name": "organization_affinities_organization_id_organizations_id_fk",
+          "tableFrom": "organization_affinities",
+          "tableTo": "organizations",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_affinities_affinity_id_affinities_id_fk": {
+          "name": "organization_affinities_affinity_id_affinities_id_fk",
+          "tableFrom": "organization_affinities",
+          "tableTo": "affinities",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "affinity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "lpdd.organization_categories": {
+      "name": "organization_categories",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_categories_organization_id_organizations_id_fk": {
+          "name": "organization_categories_organization_id_organizations_id_fk",
+          "tableFrom": "organization_categories",
+          "tableTo": "organizations",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_categories_category_id_categories_id_fk": {
+          "name": "organization_categories_category_id_categories_id_fk",
+          "tableFrom": "organization_categories",
+          "tableTo": "categories",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "lpdd.organization_cities": {
+      "name": "organization_cities",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_cities_organization_id_organizations_id_fk": {
+          "name": "organization_cities_organization_id_organizations_id_fk",
+          "tableFrom": "organization_cities",
+          "tableTo": "organizations",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_cities_city_id_cities_id_fk": {
+          "name": "organization_cities_city_id_cities_id_fk",
+          "tableFrom": "organization_cities",
+          "tableTo": "cities",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "lpdd.organization_contacts": {
+      "name": "organization_contacts",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_contacts_organization_id_organizations_id_fk": {
+          "name": "organization_contacts_organization_id_organizations_id_fk",
+          "tableFrom": "organization_contacts",
+          "tableTo": "organizations",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_contacts_email_unique": {
+          "name": "organization_contacts_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "lpdd.organization_industries": {
+      "name": "organization_industries",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry_id": {
+          "name": "industry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_industries_organization_id_organizations_id_fk": {
+          "name": "organization_industries_organization_id_organizations_id_fk",
+          "tableFrom": "organization_industries",
+          "tableTo": "organizations",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_industries_industry_id_industries_id_fk": {
+          "name": "organization_industries_industry_id_industries_id_fk",
+          "tableFrom": "organization_industries",
+          "tableTo": "industries",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "industry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "lpdd.organization_services": {
+      "name": "organization_services",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_services_organization_id_organizations_id_fk": {
+          "name": "organization_services_organization_id_organizations_id_fk",
+          "tableFrom": "organization_services",
+          "tableTo": "organizations",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_services_service_id_key_services_id_fk": {
+          "name": "organization_services_service_id_key_services_id_fk",
+          "tableFrom": "organization_services",
+          "tableTo": "key_services",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "lpdd.organizations": {
+      "name": "organizations",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'now()'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'now()'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_unique": {
+          "name": "organizations_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "organizations_website_url_unique": {
+          "name": "organizations_website_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "website_url"
+          ]
+        }
+      }
+    },
+    "lpdd.user_organizations": {
+      "name": "user_organizations",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'now()'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organizations_user_id_users_id_fk": {
+          "name": "user_organizations_user_id_users_id_fk",
+          "tableFrom": "user_organizations",
+          "tableTo": "users",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_organizations_organization_id_organizations_id_fk": {
+          "name": "user_organizations_organization_id_organizations_id_fk",
+          "tableFrom": "user_organizations",
+          "tableTo": "organizations",
+          "schemaTo": "lpdd",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "lpdd.users": {
+      "name": "users",
+      "schema": "lpdd",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supabase_id": {
+          "name": "supabase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org_admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'now()'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'now()'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_supabase_id_unique": {
+          "name": "users_supabase_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "supabase_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "lpdd": "lpdd"
+  },
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1772151079172,
       "tag": "20260227001119_red_vivisector",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1772232183399,
+      "tag": "20260227224303_hard_paper_doll",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -147,3 +147,14 @@ export const FeaturedOrgsTable = lpddSchema.table("featured_orgs", {
   org_id: integer("org_id").notNull().unique().references(() => OrganizationsTable.id),
   display_order: integer("display_order").notNull(),
 });
+
+export const KeyServicesTable = lpddSchema.table("key_services", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull().unique(),
+});
+
+export const OrganizationServices = lpddSchema.table("organization_services", {
+  id: serial("id").primaryKey(),
+  organization_id: integer("organization_id").references(() => OrganizationsTable.id),
+  service_id: integer("service_id").references(() => KeyServicesTable.id),
+});

--- a/drizzle/seed/data.ts
+++ b/drizzle/seed/data.ts
@@ -269,6 +269,28 @@ export const orgCityMappings = [
   },
 ];
 
+export const directoryServices = [
+  { name: "Mentorship" },
+  { name: "Networking" },
+  { name: "Leadership Development" },
+  { name: "Career Advancement" },
+  { name: "Professional Development" },
+  { name: "Entrepreneurship" },
+  { name: "Funding & Investment" },
+  { name: "Community Building" },
+];
+
+export const orgServiceMappings = [
+  { directoryName: "Techqueria", services: ["Mentorship", "Networking", "Career Advancement", "Professional Development", "Community Building"] },
+  { directoryName: "ALPFA", services: ["Networking", "Leadership Development", "Career Advancement", "Professional Development"] },
+  { directoryName: "Hispanic Alliance for Career Enhancement (HACE)", services: ["Mentorship", "Leadership Development", "Career Advancement", "Professional Development"] },
+  { directoryName: "Angeles Investors", services: ["Mentorship", "Entrepreneurship", "Funding & Investment"] },
+  { directoryName: "SHPE", services: ["Mentorship", "Networking", "Leadership Development", "Professional Development", "Community Building"] },
+  { directoryName: "Latinas in Tech", services: ["Networking", "Career Advancement", "Professional Development", "Community Building"] },
+  { directoryName: "Chicago Innovation", services: ["Networking", "Entrepreneurship", "Community Building"] },
+  { directoryName: "1871", services: ["Mentorship", "Networking", "Professional Development", "Entrepreneurship", "Funding & Investment"] },
+];
+
 export const directoryEvents = [
   {
     name: "The Innovation Forecast: the Next 25 Years",

--- a/drizzle/seed/seed.ts
+++ b/drizzle/seed/seed.ts
@@ -13,6 +13,8 @@ import {
   directoryEvents,
   eventOrgMappings,
   eventIndustryMappings,
+  directoryServices,
+  orgServiceMappings,
 } from "./data";
 import {
   OrganizationsTable,
@@ -28,6 +30,8 @@ import {
   EventOrganizations,
   EventIndustries,
   FeaturedOrgsTable,
+  KeyServicesTable,
+  OrganizationServices,
 } from "../schema";
 import { directoryIndustries } from "./data";
 
@@ -46,6 +50,8 @@ async function main() {
     await seedEventOrganizations();
     await seedEventIndustries();
     await seedFeaturedOrgs();
+    await seedServices();
+    await seedOrganizationServices();
   } catch (e) {
     console.error(e);
     throw new Error("Seed error...");
@@ -561,4 +567,79 @@ async function seedFeaturedOrgs() {
     console.log(`Inserted featured org: ${name} (order ${displayOrder})`);
   }
   console.log("Seed featured orgs finished...");
+}
+
+async function seedServices() {
+  console.log("Seed services started...");
+  for (const service of directoryServices) {
+    const existingService = await db
+      .select()
+      .from(KeyServicesTable)
+      .where(eq(KeyServicesTable.name, service.name))
+      .limit(1);
+    if (existingService.length > 0) {
+      console.log(`Skipping existing service: ${service.name}`);
+      continue;
+    }
+
+    await db.insert(KeyServicesTable).values(service);
+    console.log(`Inserted service: ${service.name}`);
+  }
+  console.log("Seed services finished...");
+}
+
+async function seedOrganizationServices() {
+  console.log("Seed organization services started...");
+  for (const mapping of orgServiceMappings) {
+    const [organization] = await db
+      .select()
+      .from(OrganizationsTable)
+      .where(eq(OrganizationsTable.name, mapping.directoryName))
+      .limit(1);
+
+    if (!organization) {
+      console.log(`Organization not found: ${mapping.directoryName}`);
+      continue;
+    }
+
+    for (const serviceName of mapping.services) {
+      const [service] = await db
+        .select()
+        .from(KeyServicesTable)
+        .where(eq(KeyServicesTable.name, serviceName))
+        .limit(1);
+
+      if (!service) {
+        console.log(`Service not found: ${serviceName}`);
+        continue;
+      }
+
+      const existingMapping = await db
+        .select()
+        .from(OrganizationServices)
+        .where(
+          and(
+            eq(OrganizationServices.organization_id, organization.id),
+            eq(OrganizationServices.service_id, service.id)
+          )
+        )
+        .limit(1);
+
+      if (existingMapping.length > 0) {
+        console.log(
+          `Mapping already exists for ${mapping.directoryName} -> ${serviceName}`
+        );
+        continue;
+      }
+
+      await db.insert(OrganizationServices).values({
+        organization_id: organization.id,
+        service_id: service.id,
+      });
+      console.log(
+        `Inserted mapping: ${mapping.directoryName} -> ${serviceName}`
+      );
+    }
+  }
+  console.log("Seeding organization services completed.");
 }

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -1,0 +1,11 @@
+import { fetchServices } from "@/lib/dbOperations";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const services = await fetchServices();
+    return NextResponse.json({ services });
+  } catch (error) {
+    return NextResponse.json({ error: error }, { status: 500 });
+  }
+}

--- a/src/app/organizations/[id]/page.tsx
+++ b/src/app/organizations/[id]/page.tsx
@@ -53,6 +53,7 @@ export default async function Page({ params }: { params: Promise<PageProps> }) {
     logo_url,
     website_url,
     industries,
+    services = [],
     photo_url,
     cities = [],
     events = [],
@@ -173,6 +174,18 @@ export default async function Page({ params }: { params: Promise<PageProps> }) {
                 <Tags tags={industries} />
               </section>
             )}
+          </div>
+        )}
+
+        {/* Key Services */}
+        {services.length > 0 && (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <section className="rounded-xl border border-border bg-card p-6 shadow-lg">
+              <h2 className="mb-4 font-lexend text-lg font-bold uppercase tracking-wide sm:text-xl">
+                Key Services
+              </h2>
+              <Tags tags={services} type="services" />
+            </section>
           </div>
         )}
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -13,6 +13,7 @@ export interface DirectoryOrgType {
   description: string;
   website_url: string;
   industries: IndustryType[];
+  services: ServiceType[];
   photo_url: string;
   video_url: string;
   cities: CityType[];
@@ -20,6 +21,11 @@ export interface DirectoryOrgType {
 }
 
 export interface IndustryType {
+  id: number;
+  name: string;
+}
+
+export interface ServiceType {
   id: number;
   name: string;
 }
@@ -60,6 +66,10 @@ export interface OrganizationsApiResponse {
 
 export interface IndustriesApiResponse {
   industries: IndustryType[];
+}
+
+export interface ServicesApiResponse {
+  services: ServiceType[];
 }
 
 export interface CitiesApiResponse {

--- a/src/components/Directory/Tags/index.tsx
+++ b/src/components/Directory/Tags/index.tsx
@@ -1,17 +1,22 @@
 "use client";
 
-import { IndustryType } from "@/app/types";
-import IndustryPill from "@/components/common/IndustryPill";
-
-interface Props {
-  tags: IndustryType[];
+interface TagsProps {
+  tags: { id: number; name: string }[];
+  type?: "industries" | "services";
 }
 
-export default function Tags({ tags }: Props) {
+export default function Tags({ tags, type = "industries" }: TagsProps) {
+  const pillClass =
+    type === "services"
+      ? "inline-block rounded-full bg-brand px-3 py-1 text-label font-lexend text-white"
+      : "inline-block rounded-full bg-accent px-3 py-1 text-label font-lexend";
+
   return (
     <div className="mt-1 flex flex-wrap gap-2 pb-4">
       {tags.map((tag) => (
-        <IndustryPill key={tag.id} industry={tag} />
+        <span key={tag.id} className={pillClass}>
+          {tag.name}
+        </span>
       ))}
     </div>
   );

--- a/src/lib/dbOperations.ts
+++ b/src/lib/dbOperations.ts
@@ -9,9 +9,11 @@ import {
   EventOrganizations,
   EventIndustries,
   FeaturedOrgsTable,
+  KeyServicesTable,
+  OrganizationServices,
 } from "../../drizzle/schema";
 import { inArray, eq, and } from "drizzle-orm";
-import { DirectoryOrgType, IndustryType, CityType, EventType } from "@/app/types";
+import { DirectoryOrgType, IndustryType, CityType, EventType, ServiceType } from "@/app/types";
 
 // ** ENRICHMENT HELPERS **
 
@@ -20,9 +22,10 @@ async function enrichOrganizations(
 ): Promise<DirectoryOrgType[]> {
   if (organizations.length === 0) return [];
 
-  const [orgIndustryMappings, orgCityMappings] = await Promise.all([
+  const [orgIndustryMappings, orgCityMappings, orgServiceMappings] = await Promise.all([
     fetchOrgIndustryMappings(organizations),
     fetchOrgCityMappings(organizations),
+    fetchOrgServiceMappings(organizations),
   ]);
 
   const industryIds = orgIndustryMappings
@@ -31,10 +34,14 @@ async function enrichOrganizations(
   const cityIds = orgCityMappings
     .map((mapping) => mapping.city_id)
     .filter((id): id is number => id !== null);
+  const serviceIds = orgServiceMappings
+    .map((mapping) => mapping.service_id)
+    .filter((id): id is number => id !== null);
 
-  const [industries, cities] = await Promise.all([
+  const [industries, cities, services] = await Promise.all([
     fetchIndustries(industryIds),
     fetchCities(cityIds),
+    fetchServices(serviceIds),
   ]);
 
   return mapDataToOrganizations(
@@ -42,7 +49,9 @@ async function enrichOrganizations(
     orgIndustryMappings,
     industries,
     orgCityMappings,
-    cities
+    cities,
+    orgServiceMappings,
+    services
   );
 }
 
@@ -155,6 +164,23 @@ export async function fetchIndustries(
   return industries;
 }
 
+export async function fetchServices(
+  serviceIds?: number[]
+): Promise<ServiceType[]> {
+  const query = db
+    .select({
+      id: KeyServicesTable.id,
+      name: KeyServicesTable.name,
+    })
+    .from(KeyServicesTable);
+
+  if (serviceIds && serviceIds.length > 0) {
+    query.where(inArray(KeyServicesTable.id, serviceIds));
+  }
+
+  return await query;
+}
+
 export async function fetchCities(cityIds?: number[]): Promise<CityType[]> {
   const query = db
     .select({
@@ -220,12 +246,29 @@ async function fetchOrgCityMappings(organizations: any[]) {
   return orgCityMappings;
 }
 
+async function fetchOrgServiceMappings(organizations: any[]) {
+  const orgIds = organizations.map((org) => org.id);
+  if (orgIds.length === 0) return [];
+
+  const orgServiceMappings = await db
+    .select({
+      organization_id: OrganizationServices.organization_id,
+      service_id: OrganizationServices.service_id,
+    })
+    .from(OrganizationServices)
+    .where(inArray(OrganizationServices.organization_id, orgIds));
+
+  return orgServiceMappings;
+}
+
 function mapDataToOrganizations(
   organizations: any[],
   industryMappings: any[],
   industries: any[],
   cityMappings: any[],
-  cities: any[]
+  cities: any[],
+  serviceMappings: any[],
+  services: any[]
 ) {
   const organizationsWithData = organizations.map((org) => ({
     ...org,
@@ -245,6 +288,13 @@ function mapDataToOrganizations(
         return city || null;
       })
       .filter((city): city is CityType => city !== null),
+    services: serviceMappings
+      .filter((mapping) => mapping.organization_id === org.id)
+      .map((mapping): ServiceType | null => {
+        const service = services.find((s) => s.id === mapping.service_id);
+        return service || null;
+      })
+      .filter((service): service is ServiceType => service !== null),
   }));
 
   return organizationsWithData;


### PR DESCRIPTION
## Summary
- Adds `key_services` and `organization_services` DB tables (schema + migration) for a many-to-many services taxonomy
- Enriches org data with services alongside existing industries/cities, exposed via `GET /api/services`
- Displays a **Key Services** section on org profile pages using dark navy pills (consistent half-width grid on desktop)
- Generalizes the `Tags` component with a `type` prop (`"industries"` | `"services"`) for distinct pill colors
- Seeds 8 services (Mentorship, Networking, Leadership Development, etc.) and 33 org-service mappings

## Test plan
- [x] Hit `GET /api/services` — confirm 8 services returned
- [x] Visit `/organizations/[id]` for a seeded org (e.g. Techqueria, ALPFA) — confirm Key Services section appears with navy pills
- [x] Confirm Key Services box matches the width of Contact Info / Focus Industries cards above it on desktop
- [x] Confirm orgs with no services (e.g. Latinas in Nursing) don't show the section
- [x] Confirm existing industry gold pills are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)