### PR TITLE
Add dark mode feature flag

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,39 +43,37 @@
   --icon-fg: hsl(0 0% 100% / 1);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground: hsl(0 0% 100% / 1);
-    --secondary-foreground: hsl(210 8% 68% / 1);
-    --background: hsl(0 0% 7% / 1);
-    --background-end: hsl(210 53% 15% / 1);
-    --card: hsl(0 0% 9% / 1);
-    --card-hover: hsl(240 15% 20% / 1);
-    --border: hsl(0 0% 24% / 1);
-    --brand-gold: hsl(43 79% 42% / 1);
-    --primary: hsl(222 60% 24% / 1);
-    --primary-hover: hsl(222 60% 14% / 1);
-    --brand: hsl(214deg 51% 8%);
-    --primary: hsl(222deg 60% 48%);
-    --secondary: hsl(209deg 56% 48%);
-    --accent: hsl(43deg 79% 48%);
+html.dark {
+  --foreground: hsl(0 0% 100% / 1);
+  --secondary-foreground: hsl(210 8% 68% / 1);
+  --background: hsl(0 0% 7% / 1);
+  --background-end: hsl(210 53% 15% / 1);
+  --card: hsl(0 0% 9% / 1);
+  --card-hover: hsl(240 15% 20% / 1);
+  --border: hsl(0 0% 24% / 1);
+  --brand-gold: hsl(43 79% 42% / 1);
+  --primary: hsl(222 60% 24% / 1);
+  --primary-hover: hsl(222 60% 14% / 1);
+  --brand: hsl(214deg 51% 8%);
+  --primary: hsl(222deg 60% 48%);
+  --secondary: hsl(209deg 56% 48%);
+  --accent: hsl(43deg 79% 48%);
 
-    --chip-gradient-from: hsl(224deg 42% 20%);
-    --chip-gradient-via: hsl(240deg 42% 18%);
-    --chip-gradient-to: hsl(240deg 49% 34%);
+  --chip-gradient-from: hsl(224deg 42% 20%);
+  --chip-gradient-via: hsl(240deg 42% 18%);
+  --chip-gradient-to: hsl(240deg 49% 34%);
 
-    --logo-line-mobile: hsl(0deg 0% 100%);
+  --logo-line-mobile: hsl(0deg 0% 100%);
 
-    /* shadcn */
-    --sidebar-background: hsl(240 5.9% 10%);
-    --sidebar-foreground: hsl(240 4.8% 95.9%);
-    --sidebar-primary: hsl(224.3 76.3% 48%);
-    --sidebar-primary-foreground: hsl(0 0% 100%);
-    --sidebar-accent: hsl(240 3.7% 15.9%);
-    --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
-    --sidebar-border: hsl(240 3.7% 15.9%);
-    --sidebar-ring: hsl(217.2 91.2% 59.8%);
-  }
+  /* shadcn */
+  --sidebar-background: hsl(240 5.9% 10%);
+  --sidebar-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-primary: hsl(224.3 76.3% 48%);
+  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-accent: hsl(240 3.7% 15.9%);
+  --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-border: hsl(240 3.7% 15.9%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,11 +10,20 @@ import { getBodyFont, getFontVariables } from "@/lib/utils";
 import { APP_NAME, APP_DESCRIPTION, APP_DESCRIPTION_LONG } from "@/lib/constants";
 import { GoogleAnalytics } from "@next/third-parties/google";
 
+const darkModeDisabled = process.env.NEXT_PUBLIC_DISABLE_DARK_MODE === "true";
+
 const Base = ({ children }: PropsWithChildren) => {
   return (
     <html lang="en" className={getFontVariables()}>
       <head>
         <StructuredData />
+        {!darkModeDisabled && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `if(window.matchMedia('(prefers-color-scheme:dark)').matches)document.documentElement.classList.add('dark')`,
+            }}
+          />
+        )}
       </head>
       <body className={`min-h-screen ${getBodyFont()}`}>
         <Providers>{children}</Providers>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -122,7 +122,7 @@ const config: Config = {
       });
     },
   ],
-  darkMode: "media",
+  darkMode: "class",
 };
 
 export default config;


### PR DESCRIPTION
## Summary

- Switches `darkMode` from `"media"` to `"class"` in Tailwind so dark mode is controlled by a `dark` class on `<html>` rather than the OS media query directly
- Moves CSS variable overrides from `@media (prefers-color-scheme: dark)` to `html.dark` selector
- Adds a synchronous inline script in `<head>` that detects OS preference and sets the `dark` class before first paint (no flash)
- When `NEXT_PUBLIC_DISABLE_DARK_MODE=true` is set in Netlify, the script is skipped entirely → always light mode

## Usage

To disable dark mode in Netlify, add:
```
NEXT_PUBLIC_DISABLE_DARK_MODE=true
```

To re-enable, remove the variable — auto OS preference detection resumes.

## Test plan

- [x] Run locally without env var — verify dark mode follows OS preference with no flash
- [x] Set `NEXT_PUBLIC_DISABLE_DARK_MODE=true` in `.env.local`, restart dev server — verify site stays in light mode regardless of OS setting

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)