### PR TITLE
Add netlify.toml with cache headers to prevent ChunkLoadError

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,18 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"
+
+# Don't cache HTML — always revalidate so users get fresh chunk references
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+# Cache Next.js static assets forever — they have content hashes in filenames
+[[headers]]
+  for = "/_next/static/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"


### PR DESCRIPTION
Prevents stale HTML from referencing outdated JS chunk hashes after deploys. HTML pages use must-revalidate; static assets are cached immutably.