### PR TITLE
Add _headers file to fix ChunkLoadError on directory and events pages

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/*
+  Cache-Control: public, max-age=0, must-revalidate
+
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Prevents stale HTML caching that caused 404s for JS chunks after deploys.