### PR TITLE
feat: Show/hide password + gallery confirm/reorder

### DIFF
--- a/src/app/join/_components/StepContactInfo.tsx
+++ b/src/app/join/_components/StepContactInfo.tsx
@@ -1,3 +1,5 @@
+import { PasswordInput } from "@/components/common/PasswordInput";
+
 interface StepContactInfoProps {
   data: {
     first_name: string;
@@ -85,14 +87,13 @@ export function StepContactInfo({
         <label htmlFor="password" className="mb-1.5 text-sm font-bold text-foreground">
           Password *
         </label>
-        <input
+        <PasswordInput
           id="password"
-          type="password"
           required
           minLength={6}
           value={data.password}
           onChange={(e) => onChange("password", e.target.value)}
-          className={inputClass}
+          inputClassName={inputClass}
           placeholder="At least 6 characters"
         />
       </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { login } from "./_actions/login";
 import { FullBrand } from "@/components/common/FullBrand";
+import { PasswordInput } from "@/components/common/PasswordInput";
 
 export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
@@ -56,12 +57,11 @@ export default function LoginPage() {
               <label htmlFor="password" className="mb-2 text-sm font-bold text-foreground">
                 Password
               </label>
-              <input
+              <PasswordInput
                 id="password"
                 name="password"
-                type="password"
                 required
-                className="h-12 rounded-md border-2 border-border bg-background pl-3 text-foreground"
+                inputClassName="h-12 rounded-md border-2 border-border bg-background pl-3 text-foreground"
                 placeholder="Your password"
               />
             </div>

--- a/src/components/admin/GalleryUpload.tsx
+++ b/src/components/admin/GalleryUpload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import Image from "next/image";
 
 const MAX_PHOTOS = 6;
@@ -15,6 +15,9 @@ export function GalleryUpload({ initialUrls, folder, onPhotosChange }: GalleryUp
   const [photos, setPhotos] = useState<string[]>(initialUrls);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [confirmIndex, setConfirmIndex] = useState<number | null>(null);
+  const dragIndex = useRef<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   async function uploadFile(file: File): Promise<string | null> {
     const signRes = await fetch("/api/cloudinary/sign", {
@@ -65,26 +68,108 @@ export function GalleryUpload({ initialUrls, folder, onPhotosChange }: GalleryUp
   function remove(index: number) {
     const newPhotos = photos.filter((_, i) => i !== index);
     setPhotos(newPhotos);
+    setConfirmIndex(null);
     onPhotosChange?.(newPhotos);
+  }
+
+  function handleDragStart(index: number) {
+    dragIndex.current = index;
+  }
+
+  function handleDragOver(e: React.DragEvent, index: number) {
+    e.preventDefault();
+    setDragOverIndex(index);
+  }
+
+  function handleDrop(e: React.DragEvent, dropIndex: number) {
+    e.preventDefault();
+    const from = dragIndex.current;
+    if (from === null || from === dropIndex) {
+      dragIndex.current = null;
+      setDragOverIndex(null);
+      return;
+    }
+
+    const reordered = [...photos];
+    const [moved] = reordered.splice(from, 1);
+    reordered.splice(dropIndex, 0, moved);
+
+    setPhotos(reordered);
+    onPhotosChange?.(reordered);
+    dragIndex.current = null;
+    setDragOverIndex(null);
+  }
+
+  function handleDragEnd() {
+    dragIndex.current = null;
+    setDragOverIndex(null);
   }
 
   return (
     <div className="flex flex-col gap-3">
       <label className="text-sm font-bold text-foreground">
-        Photo Gallery <span className="font-normal text-secondary-foreground">({photos.length}/{MAX_PHOTOS})</span>
+        Photo Gallery{" "}
+        <span className="font-normal text-secondary-foreground">
+          ({photos.length}/{MAX_PHOTOS})
+        </span>
       </label>
+
+      {photos.length > 1 && (
+        <p className="text-xs text-secondary-foreground">Drag photos to reorder.</p>
+      )}
 
       <div className="grid grid-cols-3 gap-3 sm:grid-cols-6">
         {photos.map((url, i) => (
-          <div key={i} className="group relative aspect-square overflow-hidden rounded-lg border border-border">
-            <Image src={url} alt={`Gallery photo ${i + 1}`} fill sizes="150px" className="object-cover" />
-            <button
-              type="button"
-              onClick={() => remove(i)}
-              className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-black/60 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100"
-            >
-              ×
-            </button>
+          <div
+            key={url}
+            draggable
+            onDragStart={() => handleDragStart(i)}
+            onDragOver={(e) => handleDragOver(e, i)}
+            onDrop={(e) => handleDrop(e, i)}
+            onDragEnd={handleDragEnd}
+            className={`group relative aspect-square cursor-grab overflow-hidden rounded-lg border transition-all active:cursor-grabbing ${
+              dragOverIndex === i
+                ? "scale-105 border-primary ring-2 ring-primary"
+                : "border-border"
+            }`}
+          >
+            <Image
+              src={url}
+              alt={`Gallery photo ${i + 1}`}
+              fill
+              sizes="150px"
+              className="pointer-events-none object-cover"
+            />
+
+            {confirmIndex === i ? (
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/70 p-1">
+                <p className="text-center text-xs font-medium text-white">Remove?</p>
+                <div className="flex gap-1">
+                  <button
+                    type="button"
+                    onClick={() => remove(i)}
+                    className="rounded bg-red-500 px-2 py-0.5 text-xs font-medium text-white hover:bg-red-600"
+                  >
+                    Yes
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmIndex(null)}
+                    className="rounded bg-white/20 px-2 py-0.5 text-xs font-medium text-white hover:bg-white/30"
+                  >
+                    No
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setConfirmIndex(i)}
+                className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-black/60 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100"
+              >
+                ×
+              </button>
+            )}
           </div>
         ))}
 

--- a/src/components/common/PasswordInput.tsx
+++ b/src/components/common/PasswordInput.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import { EyeIcon, EyeOffIcon } from "@heroicons/react/outline";
+
+interface PasswordInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  inputClassName?: string;
+}
+
+export function PasswordInput({ inputClassName, className, ...props }: PasswordInputProps) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div className={`relative ${className ?? ""}`}>
+      <input
+        type={show ? "text" : "password"}
+        className={`w-full pr-10 ${inputClassName ?? ""}`}
+        {...props}
+      />
+      <button
+        type="button"
+        onClick={() => setShow((s) => !s)}
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-secondary-foreground hover:text-foreground"
+        tabIndex={-1}
+        aria-label={show ? "Hide password" : "Show password"}
+      >
+        {show ? (
+          <EyeOffIcon className="h-4 w-4" />
+        ) : (
+          <EyeIcon className="h-4 w-4" />
+        )}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `PasswordInput` shared component with eye icon toggle — applied to login page and join form (and accept invite on that branch)
- Gallery photo delete now shows inline Yes/No confirm overlay instead of removing immediately
- Gallery photos are drag-to-reorder — drag any photo onto another to swap positions, highlighted with a ring + scale effect; new order auto-saves via existing handler

## Test plan
- [ ] Login page → password field has eye icon, toggles visibility
- [ ] Join form step 2 → same
- [ ] Gallery → hover a photo, click ×, confirm overlay appears with Yes/No
- [ ] Gallery → drag a photo onto another → they swap, toast confirms save
- [ ] Gallery → "Drag photos to reorder" hint appears when 2+ photos exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)