### PR TITLE
fix: Org page OG metadata — correct title, image, and metadataBase

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import StructuredData from "@/components/StructuredData";
 import { PropsWithChildren } from "react";
 import { InternalNavigationLinks } from "./types";
 import { getBodyFont, getFontVariables } from "@/lib/utils";
-import { APP_NAME, APP_DESCRIPTION, APP_DESCRIPTION_LONG } from "@/lib/constants";
+import { APP_NAME, APP_DESCRIPTION, APP_DESCRIPTION_LONG, APP_URL } from "@/lib/constants";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { Toaster } from "sonner";
 
@@ -62,6 +62,7 @@ const internalLinks: InternalNavigationLinks = [
 ];
 
 export const metadata: Metadata = {
+  metadataBase: new URL(APP_URL),
   title: APP_NAME,
   description: APP_DESCRIPTION,
   openGraph: {

--- a/src/app/organizations/[slug]/page.tsx
+++ b/src/app/organizations/[slug]/page.tsx
@@ -20,13 +20,22 @@ import {
 } from "@/lib/dbOperations";
 import { APP_NAME } from "@/lib/constants";
 
+const COVER_FALLBACK =
+  "https://images.unsplash.com/photo-1540575467063-178a50c2df87?w=1200&h=400&fit=crop";
+
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const org = await fetchOrganizationBySlug(slug);
+
+  let org;
+  try {
+    org = await fetchOrganizationBySlug(slug);
+  } catch {
+    return {};
+  }
   if (!org) return {};
 
   const title = `${org.name} | ${APP_NAME}`;
@@ -35,7 +44,12 @@ export async function generateMetadata({
     : isValidString(org.description)
     ? org.description.slice(0, 160)
     : undefined;
-  const image = isValidString(org.photo_url) ? org.photo_url : undefined;
+
+  const image = isValidString(org.photo_url)
+    ? org.photo_url
+    : isValidString(org.logo_url)
+    ? org.logo_url
+    : COVER_FALLBACK;
 
   return {
     title,
@@ -43,19 +57,16 @@ export async function generateMetadata({
     openGraph: {
       title,
       description,
-      ...(image && { images: [{ url: image, width: 1200, height: 400 }] }),
+      images: [{ url: image, width: 1200, height: 400 }],
     },
     twitter: {
-      card: image ? "summary_large_image" : "summary",
+      card: "summary_large_image",
       title,
       description,
-      ...(image && { images: [image] }),
+      images: [image],
     },
   };
 }
-
-const COVER_FALLBACK =
-  "https://images.unsplash.com/photo-1540575467063-178a50c2df87?w=1200&h=400&fit=crop";
 
 interface PageProps {
   slug: string;


### PR DESCRIPTION
- Add metadataBase to root layout so Next.js resolves OG image URLs
- generateMetadata: wrap fetchOrganizationBySlug in try/catch so a DB error falls back to {} instead of crashing
- Image fallback chain: banner → logo → COVER_FALLBACK (always an image)
- Always set twitter:card to summary_large_image