### PR TITLE
chore: Upgrade heroicons v1 → v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lpdd",
       "version": "0.1.0",
       "dependencies": {
-        "@heroicons/react": "^1.0.6",
+        "@heroicons/react": "^2.2.0",
         "@next/env": "^14.2.5",
         "@next/third-parties": "^16.1.6",
         "@radix-ui/react-dialog": "^1.1.2",
@@ -1639,12 +1639,12 @@
       "license": "MIT"
     },
     "node_modules/@heroicons/react": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.6.tgz",
-      "integrity": "sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
       "license": "MIT",
       "peerDependencies": {
-        "react": ">= 16"
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@heroicons/react": "^1.0.6",
+    "@heroicons/react": "^2.2.0",
     "@next/env": "^14.2.5",
     "@next/third-parties": "^16.1.6",
     "@radix-ui/react-dialog": "^1.1.2",

--- a/src/app/admin/_components/AdminSidebar.tsx
+++ b/src/app/admin/_components/AdminSidebar.tsx
@@ -10,15 +10,15 @@ import { cn } from "@/lib/utils";
 import {
   HomeIcon,
   UserGroupIcon,
-  ClipboardListIcon,
+  ClipboardDocumentListIcon,
   UserCircleIcon,
-  LogoutIcon,
+  ArrowRightOnRectangleIcon,
   ArrowLeftIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   StarIcon,
-  UserAddIcon,
-} from "@heroicons/react/outline";
+  UserPlusIcon,
+} from "@heroicons/react/24/outline";
 import {
   Tooltip,
   TooltipContent,
@@ -55,7 +55,7 @@ const navItems: NavItem[] = [
     href: "/admin/queue",
     label: "Approval Queue",
     roles: ["system_admin"],
-    icon: ClipboardListIcon,
+    icon: ClipboardDocumentListIcon,
   },
   {
     href: "/admin/featured",
@@ -67,7 +67,7 @@ const navItems: NavItem[] = [
     href: "/admin/invites",
     label: "Manage Admins",
     roles: ["system_admin"],
-    icon: UserAddIcon,
+    icon: UserPlusIcon,
   },
 ];
 
@@ -180,7 +180,7 @@ export function AdminSidebar({ role, userName }: AdminSidebarProps) {
                   type="submit"
                   className="flex items-center gap-3 text-sm text-secondary-foreground hover:text-foreground"
                 >
-                  <LogoutIcon className="h-5 w-5 shrink-0" />
+                  <ArrowRightOnRectangleIcon className="h-5 w-5 shrink-0" />
                   <span>Sign out</span>
                 </button>
               </form>

--- a/src/app/admin/_components/DeleteOrgButton.tsx
+++ b/src/app/admin/_components/DeleteOrgButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { TrashIcon } from "@heroicons/react/outline";
+import { TrashIcon } from "@heroicons/react/24/outline";
 import { deleteOrgAction } from "../organizations/[id]/_actions/deleteOrg";
 
 interface DeleteOrgButtonProps {

--- a/src/app/organizations/[slug]/_components/OrgWebsiteLink.tsx
+++ b/src/app/organizations/[slug]/_components/OrgWebsiteLink.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { GlobeAltIcon } from "@heroicons/react/outline";
+import { GlobeAltIcon } from "@heroicons/react/24/outline";
 import { trackOrgWebsiteClick } from "@/lib/analytics";
 
 interface OrgWebsiteLinkProps {

--- a/src/app/organizations/[slug]/page.tsx
+++ b/src/app/organizations/[slug]/page.tsx
@@ -10,7 +10,7 @@ import BackButton from "@/components/common/BackButton";
 import CoverImage from "@/components/common/CoverImage";
 import { isValidString } from "@/lib/utils";
 import EventCard from "@/components/Events/EventCard";
-import { LocationMarkerIcon, GlobeAltIcon } from "@heroicons/react/outline";
+import { MapPinIcon, GlobeAltIcon } from "@heroicons/react/24/outline";
 import OrgWebsiteLink from "./_components/OrgWebsiteLink";
 import SocialLinks from "./_components/SocialLinks";
 import {
@@ -198,7 +198,7 @@ export default async function Page({ params }: { params: Promise<PageProps> }) {
                 <div className="space-y-3">
                   {isValidString(cityText) && (
                     <div className="flex items-center gap-3">
-                      <LocationMarkerIcon className="h-5 w-5 flex-shrink-0 text-primary" />
+                      <MapPinIcon className="h-5 w-5 flex-shrink-0 text-primary" />
                       <span className="text-secondary-foreground">{cityText}</span>
                     </div>
                   )}

--- a/src/components/Events/EventCard/index.tsx
+++ b/src/components/Events/EventCard/index.tsx
@@ -8,8 +8,8 @@ import { trackEventClick } from "@/lib/analytics";
 import {
   CalendarIcon,
   ClockIcon,
-  LocationMarkerIcon,
-} from "@heroicons/react/outline";
+  MapPinIcon,
+} from "@heroicons/react/24/outline";
 
 const DEFAULT_IMAGES: Record<string, string> = {
   Tech: "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?w=600&h=400&fit=crop",
@@ -113,7 +113,7 @@ export default function EventCard({
             )}
             {isValidString(locationText) && (
               <div className="flex items-center gap-2">
-                <LocationMarkerIcon className="h-4 w-4 flex-shrink-0" />
+                <MapPinIcon className="h-4 w-4 flex-shrink-0" />
                 <span>{locationText}</span>
               </div>
             )}

--- a/src/components/NavBar/MenuButton/index.tsx
+++ b/src/components/NavBar/MenuButton/index.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useSidebar } from "@/components/ui/sidebar";
-import { MenuIcon } from "@heroicons/react/outline";
+import { Bars3Icon } from "@heroicons/react/24/outline";
 
 export const MenuButton = () => {
   const { toggleSidebar } = useSidebar();
   return (
     <button className="md:hidden" onClick={toggleSidebar}>
-      <MenuIcon width={30} height={30} className="text-white" />
+      <Bars3Icon width={30} height={30} className="text-white" />
     </button>
   );
 };

--- a/src/components/common/PasswordInput.tsx
+++ b/src/components/common/PasswordInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { EyeIcon, EyeOffIcon } from "@heroicons/react/outline";
+import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
 
 interface PasswordInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   inputClassName?: string;
@@ -25,7 +25,7 @@ export function PasswordInput({ inputClassName, className, ...props }: PasswordI
         aria-label={show ? "Hide password" : "Show password"}
       >
         {show ? (
-          <EyeOffIcon className="h-4 w-4" />
+          <EyeSlashIcon className="h-4 w-4" />
         ) : (
           <EyeIcon className="h-4 w-4" />
         )}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
-import { XIcon } from '@heroicons/react/outline'
+import { XMarkIcon } from '@heroicons/react/24/outline'
 
 import { cn } from "@/lib/utils"
 
@@ -66,7 +66,7 @@ const SheetContent = React.forwardRef<
     >
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <XIcon className="h-4 w-4" />
+        <XMarkIcon className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -23,7 +23,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
-import { ChevronLeftIcon } from "@heroicons/react/outline";
+import { ChevronLeftIcon } from "@heroicons/react/24/outline";
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;


### PR DESCRIPTION
## Summary
- Updates all heroicons imports from `@heroicons/react/outline` → `@heroicons/react/24/outline`
- Renames 7 icons that changed names in v2
- Resolves the peer dep warning from the React 19 upgrade

## Icon renames
| v1 | v2 |
|---|---|
| `LocationMarkerIcon` | `MapPinIcon` |
| `MenuIcon` | `Bars3Icon` |
| `EyeOffIcon` | `EyeSlashIcon` |
| `XIcon` | `XMarkIcon` |
| `ClipboardListIcon` | `ClipboardDocumentListIcon` |
| `LogoutIcon` | `ArrowRightOnRectangleIcon` |
| `UserAddIcon` | `UserPlusIcon` |

## Verification
- TypeScript: clean
- Build: clean

## What to check on the UI
These are purely icon swaps — same visual, different import. Spot-check the following:
- **NavBar** hamburger menu (`Bars3Icon`)
- **Password input** show/hide eye toggle (`EyeSlashIcon`)
- **Event cards** location pin (`MapPinIcon`)
- **Org profile page** location pin + globe link icon
- **Admin sidebar** all nav icons (logout arrow, clipboard list, user add)
- **Sheet/modal close button** (`XMarkIcon`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)