### PR TITLE
fix: filter UI overhaul, taxonomy cleanup, remove ALPFA from featured

### DIFF
--- a/drizzle/20260313000000_rename_service_tags_conferences_summits.sql
+++ b/drizzle/20260313000000_rename_service_tags_conferences_summits.sql
@@ -1,0 +1,3 @@
+UPDATE "lpdd"."key_services" SET "name" = 'Conferences' WHERE "name" = 'In-Person Conferences & Summits';
+--> statement-breakpoint
+UPDATE "lpdd"."key_services" SET "name" = 'Summits' WHERE "name" = 'Virtual Summits';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1773264001000,
       "tag": "20260312000001_cleanup_taxonomy_data",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1773350400000,
+      "tag": "20260313000000_rename_service_tags_conferences_summits",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/seed/data.ts
+++ b/drizzle/seed/data.ts
@@ -197,22 +197,22 @@ export const directoryServices = [
   { name: "Networking Events" },
   { name: "Mentorship Programs" },
   { name: "Professional Cohorts" },
-  { name: "In-Person Conferences & Summits" },
-  { name: "Virtual Summits" },
+  { name: "Conferences" },
+  { name: "Summits" },
   { name: "Educational Events" },
   { name: "Job Board" },
 ];
 
 export const orgServiceMappings = [
-  { directoryName: "Techqueria", services: ["Networking Events", "Virtual Summits", "Professional Cohorts"] },
+  { directoryName: "Techqueria", services: ["Networking Events", "Summits", "Professional Cohorts"] },
   { directoryName: "ALPFA", services: ["Networking Events", "Mentorship Programs", "Educational Events"] },
-  { directoryName: "1871", services: ["Networking Events", "Mentorship Programs", "In-Person Conferences & Summits"] },
-  { directoryName: "SHPE", services: ["Networking Events", "Mentorship Programs", "Educational Events", "In-Person Conferences & Summits"] },
+  { directoryName: "1871", services: ["Networking Events", "Mentorship Programs", "Conferences"] },
+  { directoryName: "SHPE", services: ["Networking Events", "Mentorship Programs", "Educational Events", "Conferences"] },
   { directoryName: "Latinas in Nursing", services: ["Networking Events", "Mentorship Programs"] },
   { directoryName: "Latinas in Tech", services: ["Networking Events", "Mentorship Programs", "Educational Events"] },
   { directoryName: "Angeles Investors", services: ["Networking Events", "Job Board"] },
   { directoryName: "Hispanic Alliance for Career Enhancement (HACE)", services: ["Mentorship Programs", "Professional Cohorts", "Educational Events"] },
-  { directoryName: "Chicago Innovation", services: ["Networking Events", "In-Person Conferences & Summits"] },
+  { directoryName: "Chicago Innovation", services: ["Networking Events", "Conferences"] },
 ];
 
 export const directoryEvents = [

--- a/drizzle/seed/seed.ts
+++ b/drizzle/seed/seed.ts
@@ -453,7 +453,6 @@ async function seedFeaturedOrgs() {
   console.log("Seed featured orgs started...");
   const FEATURED = [
     { name: "Techqueria", displayOrder: 1 },
-    { name: "ALPFA", displayOrder: 2 },
     { name: "1871", displayOrder: 3 },
   ];
 

--- a/src/components/Directory/FilterDropdown/index.tsx
+++ b/src/components/Directory/FilterDropdown/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, ReactNode } from "react";
+import { useRef, useEffect, useLayoutEffect, useState, ReactNode } from "react";
 import "./checkbox.css";
 import XIcon from "@/components/Directory/icons/X";
 import Paragraph from "@/components/common/Paragraph";
@@ -40,6 +40,39 @@ export default function FilterDropdown<T extends FilterItem>({
 }: FilterDropdownProps<T>) {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const dropdownButtonRef = useRef<HTMLButtonElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [clampState, setClampState] = useState<{ visibleCount: number; overflow: number } | null>(null);
+
+  useLayoutEffect(() => {
+    const el = measureRef.current;
+    if (!el || selectedItems.length === 0) {
+      setClampState(null);
+      return;
+    }
+
+    const chips = Array.from(el.querySelectorAll("[data-chip]")) as HTMLElement[];
+    if (chips.length === 0) return;
+
+    const tops = [...new Set(chips.map((c) => c.offsetTop))].sort((a, b) => a - b);
+
+    if (tops.length <= 2) {
+      setClampState(null);
+      return;
+    }
+
+    const row3Top = tops[2];
+    const visibleCount = chips.filter((c) => c.offsetTop < row3Top).length;
+    const overflow = chips.length - visibleCount;
+
+    setClampState((prev) =>
+      prev?.visibleCount === visibleCount && prev?.overflow === overflow
+        ? prev
+        : { visibleCount, overflow }
+    );
+  }, [selectedItems]);
+
+  const overflow = clampState?.overflow ?? 0;
+  const visibleItems = clampState ? selectedItems.slice(0, clampState.visibleCount) : selectedItems;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -151,22 +184,49 @@ export default function FilterDropdown<T extends FilterItem>({
       </div>
 
       {/* Item Chips Container */}
-      <div
-        className={`flex w-full flex-wrap gap-2 ${
-          selectedItems.length === 0 ? "mt-0" : "mt-4"
-        }`}
-      >
-        {selectedItems.map((item: T) => (
-          <button
-            key={item.id !== undefined ? item.id : item.name}
-            onClick={() => removeItem(item)}
-            className={`flex items-center space-x-2 rounded-full px-3 py-1 focus:outline-none ${chipClassName}`}
+      {selectedItems.length > 0 && (
+        <div className="relative mt-4">
+          {/* Hidden measurement div — always renders all chips at full width for accurate row detection */}
+          <div
+            ref={measureRef}
+            className="invisible absolute w-full flex flex-wrap gap-2 pointer-events-none"
+            aria-hidden="true"
           >
-            <Paragraph className="text-label font-lexend">{item.name}</Paragraph>
-            <XIcon />
-          </button>
-        ))}
-      </div>
+            {selectedItems.map((item: T) => (
+              <button
+                data-chip
+                key={item.id !== undefined ? item.id : item.name}
+                className={`flex items-center space-x-2 rounded-full px-3 py-1 ${chipClassName}`}
+              >
+                <Paragraph className="text-label font-lexend">{item.name}</Paragraph>
+                <XIcon />
+              </button>
+            ))}
+          </div>
+
+          {/* Visible chips + inline overflow badge */}
+          <div className="flex w-full flex-wrap gap-2">
+            {visibleItems.map((item: T) => (
+              <button
+                key={item.id !== undefined ? item.id : item.name}
+                onClick={() => removeItem(item)}
+                className={`flex items-center space-x-2 rounded-full px-3 py-1 focus:outline-none ${chipClassName}`}
+              >
+                <Paragraph className="text-label font-lexend">{item.name}</Paragraph>
+                <XIcon />
+              </button>
+            ))}
+            {overflow > 0 && (
+              <button
+                onClick={() => setIsDropdownOpen(true)}
+                className="rounded-full border border-border px-3 py-1 text-secondary-foreground hover:bg-muted"
+              >
+                <Paragraph className="text-label font-lexend">And {overflow} more...</Paragraph>
+              </button>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Directory/icons/Filter/index.tsx
+++ b/src/components/Directory/icons/Filter/index.tsx
@@ -6,7 +6,6 @@ const FilterIcon = () => {
       viewBox="0 0 40 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className="text-black"
     >
       <path
         d="M2 2L38 5.11111M6 8.22222L34 11.3333M10 14.4444L30 17.5556M14 20.6667L26 23.7778M18 26.8889L22 30"

--- a/src/components/Directory/index.tsx
+++ b/src/components/Directory/index.tsx
@@ -21,6 +21,10 @@ import LoadingResults from "./LoadingResults";
 import Header1 from "../common/Header1";
 import type { FilterConfig } from "@/types/filters";
 
+// Keys listed here are hidden from the directory filter UI.
+// Remove a key to re-enable it when the backing feature is ready.
+const HIDDEN_FILTERS: string[] = ["communities"];
+
 const filterConfigs: FilterConfig[] = [
   {
     key: "industry",
@@ -40,10 +44,10 @@ const filterConfigs: FilterConfig[] = [
   },
   {
     key: "services",
-    label: "Filter by Key Service",
+    label: "Filter by Key Services",
     icon: <FilterIcon />,
-    buttonClassName: "bg-gray-300 dark:bg-gray-400 dark:text-black",
-    chipClassName: "bg-gray-300 dark:bg-gray-400",
+    buttonClassName: "bg-primary text-white",
+    chipClassName: "bg-primary text-white",
     accentColor: "var(--neutral)",
     analyticsKey: "key_service",
   },
@@ -158,31 +162,32 @@ export default function Directory({ className = "" }: { className?: string }) {
       <Header1 className="pb-8 text-center">The Directory</Header1>
       <div className="min-h-96 w-full rounded-lg border border-border bg-background p-4 shadow-lg sm:min-h-[520px] lg:w-[896px] dark:shadow-gray-800">
         {!isLoading && (
-          //TODO: Fix spacing on desktop
-          <div className="mb-6 flex flex-col gap-y-4 md:flex-row md:flex-wrap md:gap-x-2 md:gap-y-2">
-            {filterConfigs.map((config) => (
-              <FilterDropdown
-                key={config.key}
-                label={config.label}
-                icon={config.icon}
-                items={filterItems[config.key]}
-                selectedItems={selectedItems[config.key]}
-                setSelectedItems={setSelectedItemsMap[config.key]}
-                isDropdownOpen={openFilter === config.key}
-                setIsDropdownOpen={(isOpen) =>
-                  setOpenFilter(isOpen ? config.key : null)
-                }
-                buttonClassName={config.buttonClassName}
-                chipClassName={config.chipClassName}
-                accentColor={config.accentColor}
-                widthClassName="md:w-[calc(50%-0.25rem)]"
-                onItemSelect={(val, selected) =>
-                  selected
-                    ? trackFilterApplied(config.analyticsKey, val, "directory")
-                    : trackFilterRemoved(config.analyticsKey, val, "directory")
-                }
-              />
-            ))}
+          <div className="mb-6 flex flex-col gap-2 md:flex-row">
+            {filterConfigs
+              .filter((config) => !HIDDEN_FILTERS.includes(config.key))
+              .map((config) => (
+                <FilterDropdown
+                  key={config.key}
+                  label={config.label}
+                  icon={config.icon}
+                  items={filterItems[config.key]}
+                  selectedItems={selectedItems[config.key]}
+                  setSelectedItems={setSelectedItemsMap[config.key]}
+                  isDropdownOpen={openFilter === config.key}
+                  setIsDropdownOpen={(isOpen) =>
+                    setOpenFilter(isOpen ? config.key : null)
+                  }
+                  buttonClassName={config.buttonClassName}
+                  chipClassName={config.chipClassName}
+                  accentColor={config.accentColor}
+                  widthClassName="md:flex-1"
+                  onItemSelect={(val, selected) =>
+                    selected
+                      ? trackFilterApplied(config.analyticsKey, val, "directory")
+                      : trackFilterRemoved(config.analyticsKey, val, "directory")
+                  }
+                />
+              ))}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Caps filter chips at 2 rows with inline \"And X more...\" overflow badge (hidden measurement div approach)
- Hides communities filter via `HIDDEN_FILTERS` constant — one line to re-enable when Programs (#126) ships
- 3 equal-width filters on desktop; Key Services gets primary blue (`bg-primary`) treatment
- `FilterIcon` now inherits `currentColor` instead of hardcoded black
- Renames \"Filter by Key Service\" → \"Filter by Key Services\"
- Splits \"In-Person Conferences & Summits\" / \"Virtual Summits\" → \"Conferences\" / \"Summits\" in seed + adds DB migration
- Removes ALPFA from featured orgs seed

## Test plan
- [x] Select 3+ filters in Industry — confirm chips cap at 2 rows with \"And X more...\" badge inline
- [x] Confirm Community filter is hidden from directory
- [ ] Confirm 3 filters display as equal thirds on desktop
- [ ] Key Services button and chips render in primary blue with white text/icons
- [ ] Netlify deploy applies migration to rename Conferences/Summits tags
- [ ] ALPFA no longer appears as featured org

🤖 Generated with [Claude Code](https://claude.com/claude-code)